### PR TITLE
Expose createMappedSelectorCreator to api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,12 +57,12 @@ export const mapMemoize = (fn, equalityCheck) =>
 // wrapping the result func and defaultMemoize for wrapping the selector. It
 // sucks that we're relying on an implementation detail but I'll be back to fix
 // this code again whenever it breaks :)
-function createMappedSelectorCreator(memoize) {
+export function createMappedSelectorCreator(memoize, ...memoizeOptions) {
   return createSelectorCreator((fn, mapmem) => {
     if (mapmem === true) {
-      return memoize(fn);
+      return memoize(fn, ...memoizeOptions);
     } else {
-      return defaultMemoize(fn);
+      return defaultMemoize(fn, ...memoizeOptions);
     }
   }, true);
 }


### PR DESCRIPTION
I want to be able to specify a custom equality function to avoid rerunning my subselectors when the value doesn't change as it will create a lot of work for react to recompute the state tree. To do this I would like to be able to do the following

```js
import Immutable from 'immutable';
import { createMappedSelectorCreator, mapMemoize } from 'reselect-map';

const createImmutableMapSelector = createMappedSelectorCreator(
  mapMemoize,
  Immutable.is
);
```